### PR TITLE
Fix issue collection from allure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ __pycache__/
 .coverage
 coverage.xml
 
+# Allure
+allure-results/
+allure-report/
+
 # Distribution / packaging
 build/
 develop-eggs/

--- a/testtrain_pytest.py
+++ b/testtrain_pytest.py
@@ -198,12 +198,25 @@ def _extract_metadata(item):
         })
     
     allure_links = []
+    seen_urls = set()
     for mark in item.iter_markers(name="allure_link"):
         if mark.kwargs.get("link_type") == "issue":
-            issue = {"url": mark.args[0] if mark.args else ""}
+            url = mark.args[0] if mark.args else ""
+            if url not in seen_urls:
+                issue = {"url": url}
+                if mark.kwargs.get("name"):
+                    issue["name"] = mark.kwargs["name"]
+                allure_links.append(issue)
+                seen_urls.add(url)
+
+    for mark in item.iter_markers(name="issue"):
+        url = str(mark.args[0]) if mark.args else ""
+        if url not in seen_urls:
+            issue = {"url": url}
             if mark.kwargs.get("name"):
                 issue["name"] = mark.kwargs["name"]
             allure_links.append(issue)
+            seen_urls.add(url)
 
     allure_labels = []
     try:


### PR DESCRIPTION
Modified `testtrain_pytest.py` to extract both `allure_link` (with `link_type="issue"`) and pytest `issue` markers from both the test class and method. The extracted issues are deduplicated by URL to ensure the API receives all correctly assigned issues for the test without duplication. Additionally, added `allure-results/` and `allure-report/` to `.gitignore` to prevent tracking of test artifacts.

---
*PR created automatically by Jules for task [10302991900115980149](https://jules.google.com/task/10302991900115980149) started by @njxqlus*