### PR TITLE
Smart clear Allure parameter values

### DIFF
--- a/src/testtrain_pytest/__init__.py
+++ b/src/testtrain_pytest/__init__.py
@@ -290,6 +290,17 @@ def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
 
 
+def _smart_strip_quotes(val: str) -> str:
+    """
+    Remove wrapping single quotes from a string if it has content inside.
+    Allure often wraps parameter values in extra single quotes (e.g. "'val'").
+    We strip them ONLY if the string is longer than 2 characters and starts/ends with '.
+    """
+    if len(val) > 2 and val.startswith("'") and val.endswith("'"):
+        return val[1:-1]
+    return val
+
+
 def _get_allure_result_data() -> dict:
     """Attempts to extract the current test's Allure data (name, steps, parameters)."""
     res = {"name": None, "steps": None, "parameters": None}
@@ -326,7 +337,7 @@ def _get_allure_result_data() -> dict:
                     res["parameters"] = [
                         {
                             "name": getattr(p, "name", "param"),
-                            "value": str(getattr(p, "value", "")),
+                            "value": _smart_strip_quotes(str(getattr(p, "value", ""))),
                             "mode": str(getattr(p, "mode", "default") or "default"),
                         }
                         for p in test_parameters
@@ -376,7 +387,7 @@ def _map_allure_step(step) -> dict:
         mapped["parameters"] = [
             {
                 "name": getattr(p, "name", "param"),
-                "value": str(getattr(p, "value", "")),
+                "value": _smart_strip_quotes(str(getattr(p, "value", ""))),
                 "mode": str(getattr(p, "mode", "default") or "default"),
             }
             for p in step_parameters

--- a/tests/test_parameter_cleaning.py
+++ b/tests/test_parameter_cleaning.py
@@ -1,5 +1,6 @@
 import json
 
+
 def test_allure_parameter_cleaning(test_env):
     """Verify that allure parameters are cleaned of wrapping single quotes if they contain content."""
     test_env.makepyfile("""

--- a/tests/test_parameter_cleaning.py
+++ b/tests/test_parameter_cleaning.py
@@ -1,0 +1,47 @@
+import json
+
+def test_allure_parameter_cleaning(test_env):
+    """Verify that allure parameters are cleaned of wrapping single quotes if they contain content."""
+    test_env.makepyfile("""
+        import allure
+        import pytest
+
+        def test_quoting():
+            allure.dynamic.parameter("key", "id_rsa2")
+            allure.dynamic.parameter("empty", "")
+            allure.dynamic.parameter("single_quote", "'")
+            allure.dynamic.parameter("just_starts", "'start")
+            allure.dynamic.parameter("just_ends", "end'")
+    """)
+    result = test_env.runpytest(
+        "-p",
+        "testtrain_pytest",
+        "-p",
+        "no:testtrain",
+        "-p",
+        "allure_pytest",
+        "--testtrain-run-id",
+        "dummy-run",
+        "--testtrain-auth-token",
+        "dummy-token",
+        "--alluredir",
+        "allure-results",
+    )
+    result.assert_outcomes(passed=1)
+
+    with open(test_env.path / "api_calls.json", "r") as f:
+        lines = f.readlines()
+        calls = [json.loads(line) for line in lines if line.strip()]
+
+    test_entry = next(
+        (t for c in calls for t in c.get("tests", []) if "test_quoting" in t["nodeId"]),
+        None,
+    )
+    params = {p["name"]: p["value"] for p in test_entry.get("parameters", [])}
+
+    # Desired behavior:
+    assert params["key"] == "id_rsa2"
+    assert params["empty"] == "''"
+    assert params["single_quote"] == "'"
+    assert params["just_starts"] == "'start"
+    assert params["just_ends"] == "end'"


### PR DESCRIPTION
Implement "smart clear" of Allure parameter values by removing wrapping single quotes only if the value has content inside. Added a new test `tests/test_parameter_cleaning.py` to verify this behavior for various edge cases.

Fixes #12

---
*PR created automatically by Jules for task [13823188053069422849](https://jules.google.com/task/13823188053069422849) started by @njxqlus*